### PR TITLE
docs: fix createConsumer example usage

### DIFF
--- a/packages/rest-ts-axios/src/index.ts
+++ b/packages/rest-ts-axios/src/index.ts
@@ -102,7 +102,7 @@ export type ApiConsumer<T extends ApiDefinition> = {
  * });
  * 
  * // Step 3: Bind the API definition to the axios instance
- * const consumer = createConsumer(apiDefinition, myCustomAPI);
+ * const consumer = createConsumer(myCustomAPI, driver);
  * 
  * // Step 4: You can now use this object in your application to make HTTP calls to your backend:
  * const res = consumer.listAllPublications({


### PR DESCRIPTION
In the provided example, the parameters are used incorrectly.
The example lists 
```javascript
// Step 3: Bind the API definition to the axios instance
const consumer = createConsumer(apiDefinition, myCustomAPI);
```
where it probably should be 
```javascript
const consumer = createConsumer(myCustomAPI, driver);
// where
//    -  myCustomAPI is the variable we import in the example's beginning
//    - driver is the axios instance we create in the previous expression 
```